### PR TITLE
Fix Generator Cluster End Sequence not resetting on checkpoint load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,5 +362,4 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 
-*.csproj
 *.props

--- a/Patches/PowerGenerator/Patch_LG_PowerGenerator_Core_SyncStatusChanged.cs
+++ b/Patches/PowerGenerator/Patch_LG_PowerGenerator_Core_SyncStatusChanged.cs
@@ -52,7 +52,7 @@ namespace ExtraObjectiveSetup.Patches.PowerGenerator
                     var EventsOnInsertCell = gcDef.EventsOnInsertCell;
 
                     int eventsIndex = (int)(poweredGenerators - 1);
-                    
+
                     if(!isDropinState)
                     {
                         if (eventsIndex >= 0 && eventsIndex < EventsOnInsertCell.Count)
@@ -75,6 +75,11 @@ namespace ExtraObjectiveSetup.Patches.PowerGenerator
                             gcParent.m_endSequenceTriggered = false;
                         }
                     }
+                } 
+                else if (isDropinState)
+                {
+                    // Reloading from checkpoint and generator is unpowered, thus cluster is implicitly unfinished
+                    gcParent.m_endSequenceTriggered = false;
                 }
             }
 


### PR DESCRIPTION
If a checkpoint was saved before starting a generator cluster, completing the generator cluster and triggering the end sequence, and then reloading the checkpoint, the end sequence would not be marked as undone, likely causing a softlock.