### PR TITLE
Fix occasional desync of ObjectiveCounter

### DIFF
--- a/EntryPoint.cs
+++ b/EntryPoint.cs
@@ -20,7 +20,7 @@ namespace ExtraObjectiveSetup
     {
         public const string AUTHOR = "Inas";
         public const string PLUGIN_NAME = "ExtraObjectiveSetup";
-        public const string VERSION = "1.6.9";
+        public const string VERSION = "1.6.10";
 
         private Harmony m_Harmony;
         

--- a/Objectives/ObjectiveCounter/Counter.cs
+++ b/Objectives/ObjectiveCounter/Counter.cs
@@ -47,10 +47,7 @@ namespace ExtraObjectiveSetup.Objectives.ObjectiveCounter
                 ReachTo(count);
             }
 
-            if(SNet.IsMaster)
-            {
-                StateReplicator.SetState(new() { Count = target });
-            }
+            StateReplicator.SetStateUnsynced(new() { Count = target });
         }
 
         public void Decrement(int by)
@@ -63,10 +60,7 @@ namespace ExtraObjectiveSetup.Objectives.ObjectiveCounter
                 ReachTo(count);
             }
 
-            if (SNet.IsMaster)
-            {
-                StateReplicator.SetState(new() { Count = target });
-            }
+            StateReplicator.SetStateUnsynced(new() { Count = target });
         }
 
         internal bool TrySetupReplicator()


### PR DESCRIPTION
In occasional scenarios (at least two noted scenarios of it occurring via EventsOnElevatorLand), Master would sync the counter state to clients before the clients had run the event, thus causing clients to, for example, run events on reached Count 2, and skip the events on reached Count 1. 

The solution taken is for all players to keep track of the count locally, and use the StateReplicator only for cases of host migration, late joins, or checkpoint reloads.

Another possible solution that I took a look at was master dictating when the counter changed at all and clients would run events when it was synced to them, but this posed one main potential problem which caused me to not go with it:

If using AWO random event selections, and you had an event sequence looking like this:

```jsonc
[
  {
    "Type": "IncrementObjectiveCounter"
  },
  {
    "Type": "AwoRandomEvent" // selection pool X
  }
]
```

... and Incrementing the objective counter would also trigger a random event, with a different random pool (let's call it pool Y), then for clients the AwoRandomEvent would likely frequently run first due to running locally, thus using the random seed intended for the IncrementObjectiveCounter for the primarily defined AwoRandomEvent.

For clarity, order would be intended as, and run as for host:
```
   Increment ObjectiveCounter and sync
-> RandomEvent (pool Y)
-> RandomEvent (pool X)
```

and for client, would run as:
```
   RandomEvent (pool X)
-> sync delay
-> receive ObjectiveCounter Increment sync
-> RandomEvent (pool Y)
```