### PR TITLE
Fix AWO events not using AWO converter

### DIFF
--- a/EntryPoint.cs
+++ b/EntryPoint.cs
@@ -14,6 +14,7 @@ namespace ExtraObjectiveSetup
     [BepInDependency(MTFOUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency(MTFOPartialDataUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(InjectLibUtil.PLUGIN_GUID, BepInDependency.DependencyFlags.SoftDependency)]
+    [BepInDependency("GTFO.AWO", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("com.sinai.unityexplorer", BepInDependency.DependencyFlags.SoftDependency)] // try prevent CTD
     [BepInPlugin(AUTHOR + "." + PLUGIN_NAME, PLUGIN_NAME, VERSION)]
     [BepInIncompatibility("Amor.ExcellentObjectiveSetup")]


### PR DESCRIPTION
Fixes some cases, namely ObjectiveCounters for me, where AWO events would not be deserialized by AWO and thus would not run AWO behavior.

EOS would deserialize *before* AWO ran, so AWO's converters would not exist when the files were read. This adds a soft dependency on AWO so EOS loads second and lets AWO add its converters first.