### PR TITLE
Add event support for WardenObjective uplinks

### DIFF
--- a/EntryPoint.cs
+++ b/EntryPoint.cs
@@ -22,7 +22,7 @@ namespace ExtraObjectiveSetup
     {
         public const string AUTHOR = "Inas";
         public const string PLUGIN_NAME = "ExtraObjectiveSetup";
-        public const string VERSION = "1.6.11";
+        public const string VERSION = "1.6.13";
 
         private Harmony m_Harmony;
         

--- a/Instances/TerminalInstanceManager.cs
+++ b/Instances/TerminalInstanceManager.cs
@@ -36,7 +36,16 @@ namespace ExtraObjectiveSetup.Instances
         // key: ChainedPuzzleInstance.Pointer
         private Dictionary<IntPtr, LG_ComputerTerminal> UniqueCommandChainPuzzles { get; } = new();
 
+        private Dictionary<LG_LayerType, List<LG_ComputerTerminal>> WardenUplinks { get; } = new();
+
         private Dictionary<IntPtr, TerminalWrapper> Wrappers { get; } = new();
+
+        public LG_ComputerTerminal GetWardenUplink(LG_LayerType layer, int objectiveIndex)
+        {
+            if (WardenUplinks.TryGetValue(layer, out var list))
+                return objectiveIndex >= 0 && objectiveIndex < list.Count ? list[objectiveIndex] : null;
+            return null;
+        }
 
         public override (eDimensionIndex dim, LG_LayerType layer, eLocalZoneIndex zone) GetGlobalZoneIndex(LG_ComputerTerminal instance)
         {
@@ -86,6 +95,15 @@ namespace ExtraObjectiveSetup.Instances
             return index;
         }
 
+        public int RegisterWardenUplink(LG_ComputerTerminal terminal)
+        {
+            var layer = terminal.SpawnNode.LayerType;
+            if (!WardenUplinks.TryGetValue(layer, out var list))
+                WardenUplinks.Add(layer, list = new());
+            list.Add(terminal);
+            return list.Count - 1;
+        }
+
         public void SetupTerminalWrapper(LG_ComputerTerminal terminal)
         {
             if(Wrappers.ContainsKey(terminal.Pointer))
@@ -111,6 +129,7 @@ namespace ExtraObjectiveSetup.Instances
         {
             UniqueCommandChainPuzzles.Clear();
             Wrappers.Clear();
+            WardenUplinks.Clear();
         }
 
         private void GatherUniqueCommandChainPuzzles()

--- a/Objectives/TerminalUplink/UplinkDefinition.cs
+++ b/Objectives/TerminalUplink/UplinkDefinition.cs
@@ -60,6 +60,8 @@ namespace ExtraObjectiveSetup.Objectives.TerminalUplink
 
     public class UplinkDefinition : BaseInstanceDefinition
     {
+        public int WardenObjectiveIndex { get; set; } = -1;
+
         public bool DisplayUplinkWarning { get; set; } = true;
 
         public bool SetupAsCorruptedUplink { get; set; } = false;

--- a/Patches/Terminal/Patch_LG_ComputerTerminal_Setup.cs
+++ b/Patches/Terminal/Patch_LG_ComputerTerminal_Setup.cs
@@ -32,5 +32,13 @@ namespace ExtraObjectiveSetup.Patches.Terminal
 
             EOSLogger.Debug($"TerminalPositionOverride: {_override.LocalIndex}, {_override.LayerType}, {_override.DimensionIndex}, TerminalIndex {_override.InstanceIndex}");
         }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(LG_ComputerTerminal), nameof(LG_ComputerTerminal.SetupAsWardenObjectiveTerminalUplink))]
+        [HarmonyPatch(typeof(LG_ComputerTerminal), nameof(LG_ComputerTerminal.SetupAsWardenObjectiveCorruptedTerminalUplink))]
+        private static void Post_LG_ComputerTerminal_UplinkSetup(LG_ComputerTerminal __instance)
+        {
+            TerminalInstanceManager.Current.RegisterWardenUplink(__instance);
+        }
     }
 }


### PR DESCRIPTION
Adds event support for Warden Objective-based Uplink terminals (EventsOnCommence, EventsOnRound, EventsOnComplete).

Added a WardenObjectiveIndex field to the UplinkDefinition to facilitate this. The system uses Layer and WardenObjectiveIndex to identify a terminal, since WO uplinks can randomize position. A negative WardenObjectiveIndex (default) preserves old behavior which ignores Warden Objective terminals.