### PR TITLE
Fix WO uplink events for normal clients

### DIFF
--- a/EntryPoint.cs
+++ b/EntryPoint.cs
@@ -22,7 +22,7 @@ namespace ExtraObjectiveSetup
     {
         public const string AUTHOR = "Inas";
         public const string PLUGIN_NAME = "ExtraObjectiveSetup";
-        public const string VERSION = "1.6.13";
+        public const string VERSION = "1.6.14";
 
         private Harmony m_Harmony;
         


### PR DESCRIPTION
Fixes Warden Objective Uplink terminals not being set up correctly for clients that dropped with the host, causing events to never fire for them.

Apparently, OnEnterLevel does _not_ work for said clients.