### PR TITLE
Fix warden corrupted uplink overriding start code

### DIFF
--- a/EntryPoint.cs
+++ b/EntryPoint.cs
@@ -22,7 +22,7 @@ namespace ExtraObjectiveSetup
     {
         public const string AUTHOR = "Inas";
         public const string PLUGIN_NAME = "ExtraObjectiveSetup";
-        public const string VERSION = "1.6.14";
+        public const string VERSION = "1.6.15";
 
         private Harmony m_Harmony;
         

--- a/Patches/Uplink/StartTerminalUplinkSequence.cs
+++ b/Patches/Uplink/StartTerminalUplinkSequence.cs
@@ -117,7 +117,7 @@ namespace ExtraObjectiveSetup.Patches.Uplink
                 var uplinkConfig = UplinkObjectiveManager.Current.GetWardenDefinition(sender);
                 if (uplinkConfig == null) return;
 
-                receiver.m_command.OnEndOfQueue = new System.Action(() =>
+                receiver.m_command.OnEndOfQueue += new System.Action(() =>
                 {
                     uplinkConfig.EventsOnCommence.ForEach(e => WardenObjectiveManager.CheckAndExecuteEventsOnTrigger(e, eWardenObjectiveEventTrigger.None, true));
 


### PR DESCRIPTION
Warden corrupted uplinks were overriding the normal code that runs instead of adding to the delegate.